### PR TITLE
Enable usage of react-pdf inside a web worker

### DIFF
--- a/scripts/shim-react-pdf.js
+++ b/scripts/shim-react-pdf.js
@@ -43,6 +43,12 @@ const prependFiles = (nodeResolutionPaths, prependContent) => {
 prependFiles(
   "blob-stream",
   `
+  if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
+    // inside a web worker, the global scope is called "self"
+    self.global = self
+    self.window = self
+  }
+  
   if (typeof window !== 'undefined') {
     window.global = window;
     window.process = require('process');


### PR DESCRIPTION
Thanks a lot for this shim! As I already mentioned in diegomura/react-pdf#1317, it has helped me to run react-pdf using vite, and even inside a Vue application.
In the meantime, we have started using web workers for rendering the PDFs for performance reasons. The approach from diegomura/react-pdf#464 has served as a basis there. However, I have had to add [another shim](https://github.com/ecamp/ecamp3/pull/1924/files#diff-5140f635ef7d24e86083ea066d7736e3a30352a00641da584e3ca41a8c485c68), since in a web worker environment, `window` is not defined, but instead the global scope is called `self`.
This PR adds the fix I found to this library, in the safest way I could find. It should only have any effect if the code is currently running inside a web worker. We are able to transparently switch our implementation between running on the main thread and running in the worker, and both variants work fine with this small addition.