### PR TITLE
Update shim to work around new Buffer usage

### DIFF
--- a/scripts/shim-react-pdf.js
+++ b/scripts/shim-react-pdf.js
@@ -66,6 +66,7 @@ prependFiles(
     "@react-pdf/pdfkit/lib/pdfkit.browser.es.js",
     "@react-pdf/fontkit/lib/fontkit.browser.es.js",
     "@react-pdf/png-js/lib/png-js.browser.es.js",
+    "@react-pdf/unicode-properties/lib/unicode-properties.es.js",
   ],
   "import { Buffer } from 'buffer';"
 );


### PR DESCRIPTION
Fixes #7
Refs https://github.com/diegomura/react-pdf/issues/1317
Caused by new Buffer usage from https://github.com/diegomura/react-pdf/pull/1839
This starts occurring for @react-pdf/renderer >= 2.1.2, but the workaround should not hurt older versions either

Error which this change fixes:
```
Uncaught ReferenceError: Buffer is not defined
at node_modules/@react-pdf/unicode-properties/lib/unicode-properties.es.js (unicode-properties.es.js:268:31)
at __init (chunk-GVC7CBB2.js?v=33aefd43:15:56) at node_modules/@react-pdf/fontkit/lib/fontkit.browser.es.js (fontkit.browser.es.js:10:1)
at __init (chunk-GVC7CBB2.js?v=33aefd43:15:56) at node_modules/@react-pdf/font/lib/index.browser.js (fontkit.browser.es.js:40110:29)
at __require2 (chunk-GVC7CBB2.js?v=33aefd43:18:50) at asyncToGenerator.js:35:1
```