### PR TITLE
Revert unicode-properties shim now that it is no longer needed

### DIFF
--- a/scripts/shim-react-pdf.js
+++ b/scripts/shim-react-pdf.js
@@ -66,7 +66,6 @@ prependFiles(
     "@react-pdf/pdfkit/lib/pdfkit.browser.es.js",
     "@react-pdf/fontkit/lib/fontkit.browser.es.js",
     "@react-pdf/png-js/lib/png-js.browser.es.js",
-    "@react-pdf/unicode-properties/lib/unicode-properties.es.js",
   ],
   "import { Buffer } from 'buffer';"
 );


### PR DESCRIPTION
React-pdf now removed the @react-pdf/unicode-properties package entirely, switching back to the mainline foliojs unicode-properties package.
So our fix is no longer necessary, because it does not include any Buffer usages.
Fixes #9
Refs diegomura/react-pdf#1317