### PR TITLE
fix: error adding package in vite 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "peerDependencies": {
     "@react-pdf/renderer": "^2.0.0",
-    "vite": "^2.0.0"
+    "vite": "^2.0.0 || ^3.0.0"
   }
 }

--- a/scripts/shim-react-pdf.js
+++ b/scripts/shim-react-pdf.js
@@ -71,8 +71,8 @@ prependFiles(
 );
 prependFiles(
   [
-    "@react-pdf/font/lib/index.browser.js",
-    "@react-pdf/image/lib/index.browser.js",
+    "@react-pdf/font/lib/index.browser.es.js",
+    "@react-pdf/image/lib/index.browser.es.js",
     "restructure/src/DecodeStream.js",
     "restructure/src/EncodeStream.js",
     "restructure/src/String.js",


### PR DESCRIPTION
The error that occurs when installing the lib in the project using React PDF version 2 but with Vite 3.
<img width="548" alt="image" src="https://user-images.githubusercontent.com/38158476/188489970-d9626f03-3a97-44ef-844a-57db4bfc8929.png">


This error occurs because the '.es.' of esmodules in the file that was not found.
<img width="309" alt="image" src="https://user-images.githubusercontent.com/38158476/188490116-7420317a-5ae9-4386-8599-5e8cbde5e601.png">
